### PR TITLE
Update Route.svelte

### DIFF
--- a/src/Route.svelte
+++ b/src/Route.svelte
@@ -7,7 +7,7 @@
     const { props: sub, ...others } = given;
 
     // prune all declared props from this component
-    required = typeof required === 'object'
+    required = Object.prototype.toString.call(required) !== '[object Array]'
       ? Object.keys(required)
       : required;
     required.forEach(k => {

--- a/src/Route.svelte
+++ b/src/Route.svelte
@@ -7,6 +7,9 @@
     const { props: sub, ...others } = given;
 
     // prune all declared props from this component
+    required = typeof required === 'object'
+      ? Object.keys(required)
+      : required;
     required.forEach(k => {
       delete others[k];
     });


### PR DESCRIPTION
Fix for newer svelte versions which use an object type instead of an array type for the props.