### PR TITLE
Dynamic components

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,16 +72,37 @@ Available props:
 - `{path}` &mdash; Any segment to derive a fullpath from, default to `/`
 - `{props}` &mdash; Additional properties for rendered component
 - `{exact}` &mdash; If set, the route will render only if the route exactly matches
-- `{dynamic}` &mdash; Promise, if set will resolve and use its result as lazy-component
-- `{pending}` &mdash; String, this value is rendered during the loading of dynamic components
+- `{pending}` &mdash; Svelte-component or String; rendered during the loading of dynamic components
 - `{fallback}` &mdash; If set, the route will render only if no more routes were matched
-- `{component}` &mdash; A valid svelte-component to render if the route matches
+- `{component}` &mdash; Accepts either a valid svelte-component, a promise, or a dynamic import function
 - `{disabled}` &mdash; Boolean; Similar to condition, but for bound props
 - `{condition}` &mdash; Function; if given, the route will render only if evaluates to true
 - `{redirect}` &mdash; Alternate redirection location, only if the previous condition was true
 - `let:router` &mdash; Injects the `router` context, it also provides `failure` in case of errors
 
 > If you omit `exact`, then `/x` would match both `/` and `/x` routes &mdash; [see docs](https://www.npmjs.com/package/abstract-nested-router#params)
+
+> {component} prop examples:
+
+```html
+<script>
+  import SvelteComponent from 'path/to/svelte-component.svelte';
+</script>
+
+<Link href="/">Home</Link>
+| <Link href="/svelte-component">Svelte component</Link>
+| <Link href="/promise">Promised component</Link>
+| <Link href="/async">Async component</Link>
+
+<p>
+  <Router>
+    <Route exact>Hello World</Route>
+    <Route exact path="/svelte-component" component={SvelteComponent}/>
+    <Route exact path="/promise" component={import('path/to/other-component.svelte')}/>
+    <Route exact path="/async" component={() => import('path/to/another-component.svelte')}/>
+  </Router>
+</p>
+```
 
 ### `<Link {go} {href} {open} {title} {exact} {reload} {replace} {class} />`
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -36,7 +36,7 @@ export default {
     }),
     buble({
       objectAssign: 'Object.assign',
-      transforms: { dangerousForOf: true, asyncAwait: false },
+      transforms: { dangerousForOf: true },
     }),
     isProd && terser(),
   ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -36,7 +36,7 @@ export default {
     }),
     buble({
       objectAssign: 'Object.assign',
-      transforms: { dangerousForOf: true },
+      transforms: { dangerousForOf: true, asyncAwait: false },
     }),
     isProd && terser(),
   ],

--- a/src/Route.svelte
+++ b/src/Route.svelte
@@ -78,7 +78,7 @@
         component = module.default;
         hasLoaded = true;
       });
-    } else if (isFunction(component) && activeRouter.path === path) { // component passed as () => import()
+    } else if (activeRouter.path === path) { // component passed as () => import()
       component().then(module => {
         component = module.default;
         hasLoaded = true;

--- a/src/Route.svelte
+++ b/src/Route.svelte
@@ -1,7 +1,9 @@
 <script context="module">
   import { writable } from 'svelte/store';
   import { routeInfo } from './router';
-  import { CTX_ROUTER, CTX_ROUTE, getProps, isPromise, isSvelteComponent, isFunction } from './utils';
+  import {
+    CTX_ROUTER, CTX_ROUTE, getProps, isPromise, isSvelteComponent, isFunction,
+  } from './utils';
 </script>
 
 <script>
@@ -66,21 +68,23 @@
     activeProps = getProps($$props, thisProps);
   }
 
-  $: activeRouter && (async () => {
+  $: if (activeRouter) {
     if (!component) { // component passed as slot
       hasLoaded = true;
     } else if (isSvelteComponent(component)) { // component passed as Svelte component
       hasLoaded = true;
     } else if (isPromise(component)) { // component passed as import()
-      const {default: M} = await component;
-      component = M;
-      hasLoaded = true;
+      component.then(module => {
+        component = module.default;
+        hasLoaded = true;
+      });
     } else if (isFunction(component) && activeRouter.path === path) { // component passed as () => import()
-      const {default: M} = await component();
-      component = M;
-      hasLoaded = true;
+      component().then(module => {
+        component = module.default;
+        hasLoaded = true;
+      });
     }
-  })();
+  }
 
   onDestroy(() => {
     if (unassignRoute) {

--- a/src/Route.svelte
+++ b/src/Route.svelte
@@ -10,7 +10,6 @@
   export let key = null;
   export let path = '/';
   export let exact = null;
-  export let dynamic = null;
   export let pending = null;
   export let disabled = false;
   export let fallback = null;
@@ -19,7 +18,7 @@
   export let redirect = null;
 
   // replacement for `Object.keys(arguments[0].$$.props)`
-  const thisProps = ['key', 'path', 'exact', 'dynamic', 'pending', 'disabled', 'fallback', 'component', 'condition', 'redirect'];
+  const thisProps = ['key', 'path', 'exact', 'pending', 'disabled', 'fallback', 'component', 'condition', 'redirect'];
 
   const routeContext = getContext(CTX_ROUTE);
   const routerContext = getContext(CTX_ROUTER);

--- a/src/utils.js
+++ b/src/utils.js
@@ -124,11 +124,11 @@ export function isActive(uri, path, exact) {
 }
 
 export function isFunction(object) {
-  return Object.prototype.toString.call(object).includes('Function');
+  return typeof object === 'function';
 }
 
 export function isPromise(object) {
-  return Object.prototype.toString.call(object).includes('Promise');
+  return object && typeof object.then === 'function';
 }
 
 export function isSvelteComponent(object) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -122,3 +122,15 @@ export function isActive(uri, path, exact) {
 
   return cache[[uri, path, exact]];
 }
+
+export function isFunction(object) {
+  return Object.prototype.toString.call(object).includes('Function');
+}
+
+export function isPromise(object) {
+  return Object.prototype.toString.call(object).includes('Promise');
+}
+
+export function isSvelteComponent(object) {
+  return object && object.prototype;
+}


### PR DESCRIPTION
As we talked before, this PR introduces use of dynamic components.

Now you can pass as component property either of 4:
1. As slot - string/expression
2. Svelte component
3. import('..path/to/component') as promise
4. () => import('..path/to/component') as function for async component loading and code splitting

This makes dynamic property redundant since we can now handle all types of component in one go, without need to use additional prop. 

**Pending** property now can accept either String or Svelte component.

Tested on my local project and it work flawlessly. 

Let me know what do you think. 
A.