### PR TITLE
inlines data-failure styles for components

### DIFF
--- a/src/Route.svelte
+++ b/src/Route.svelte
@@ -97,14 +97,8 @@
   });
 </script>
 
-<style>
-  [data-failure] {
-    color: red;
-  }
-</style>
-
 {#if failure}
-  <p data-failure>{failure}</p>
+  <p style="color: red;">{failure}</p>
 {/if}
 
 {#if activeRouter}

--- a/src/Router.svelte
+++ b/src/Router.svelte
@@ -90,18 +90,13 @@
   }
 </script>
 
-<style>
-  [data-failure] {
-    border: 1px dashed silver;
-  }
-</style>
 
 {#if !disabled}
   <slot />
 {/if}
 
 {#if failure && !fallback && !nofallback}
-  <fieldset data-failure>
+  <fieldset style="border: 1px dashed silver;">
     <legend>Router failure: {path}</legend>
     <pre>{failure}</pre>
   </fieldset>


### PR DESCRIPTION
This change removes additional need of css handling as it may fail to compile in projects that use webpack and have complex scenarios where components use slot inside routes.