### PR TITLE
Second reduction

### DIFF
--- a/src/Route.svelte
+++ b/src/Route.svelte
@@ -32,7 +32,7 @@
   let activeRouter = null;
   let activeProps = {};
   let fullpath;
-  let failure;
+  // let failure;
   let hasLoaded;
 
   const fixedRoot = $routePath !== path && $routePath !== '/'
@@ -41,19 +41,19 @@
 
   try {
     if (redirect !== null && !/^(?:\w+:\/\/|\/)/.test(redirect)) {
-      throw new TypeError(`Expecting valid URL to redirect, given '${redirect}'`);
+      // throw new TypeError(`Expecting valid URL to redirect, given '${redirect}'`);
     }
 
     if (condition !== null && typeof condition !== 'function') {
-      throw new TypeError(`Expecting condition to be a function, given '${condition}'`);
+      // throw new TypeError(`Expecting condition to be a function, given '${condition}'`);
     }
 
     if (path.charAt() !== '#' && path.charAt() !== '/') {
-      throw new TypeError(`Expecting a leading slash or hash, given '${path}'`);
+      // throw new TypeError(`Expecting a leading slash or hash, given '${path}'`);
     }
 
     if (!assignRoute) {
-      throw new TypeError(`Missing top-level <Router>, given route: ${path}`);
+      // throw new TypeError(`Missing top-level <Router>, given route: ${path}`);
     }
 
     const fixedRoute = path !== fixedRoot && fixedRoot.substr(-1) !== '/'
@@ -64,7 +64,8 @@
       condition, redirect, fallback, exact,
     });
   } catch (e) {
-    failure = e;
+    // failure = e;
+    console.error(e);
   }
 
   $: if (key) {
@@ -101,15 +102,15 @@
   });
 </script>
 
-<style>
+<!-- <style>
   [data-failure] {
     color: red;
   }
-</style>
+</style> -->
 
-{#if failure}
+<!-- {#if failure}
   <p data-failure>{failure}</p>
-{/if}
+{/if} -->
 
 {#if activeRouter}
   {#if !hasLoaded}

--- a/src/Router.svelte
+++ b/src/Router.svelte
@@ -12,13 +12,13 @@
   } from 'svelte';
 
   let cleanup;
-  let failure;
+  // let failure;
   let fallback;
 
   export let path = '/';
   export let disabled = false;
   export let condition = null;
-  export let nofallback = false;
+  // export let nofallback = false;
 
   const routerContext = getContext(CTX_ROUTER);
   const basePath = routerContext ? routerContext.basePath : writable(path);
@@ -29,14 +29,15 @@
 
   try {
     if (condition !== null && typeof condition !== 'function') {
-      throw new TypeError(`Expecting condition to be a function, given '${condition}'`);
+      // throw new TypeError(`Expecting condition to be a function, given '${condition}'`);
     }
 
     if (path.charAt() !== '#' && path.charAt() !== '/') {
-      throw new TypeError(`Expecting a leading slash or hash, given '${path}'`);
+      // throw new TypeError(`Expecting a leading slash or hash, given '${path}'`);
     }
   } catch (e) {
-    failure = e;
+    // failure = e;
+    console.error(e);
   }
 
   function assignRoute(key, route, detail) {
@@ -94,19 +95,19 @@
   }
 </script>
 
-<style>
+<!-- <style>
   [data-failure] {
     border: 1px dashed silver;
   }
-</style>
+</style> -->
 
 {#if !disabled}
   <slot />
 {/if}
 
-{#if failure && !fallback && !nofallback}
+<!-- {#if failure && !fallback && !nofallback}
   <fieldset data-failure>
     <legend>Router failure: {path}</legend>
     <pre>{failure}</pre>
   </fieldset>
-{/if}
+{/if} -->


### PR DESCRIPTION
This is a test.

Removing all the code for GUI error/failure handling for a single `console.error(err)` I can save about 2 KB.

It would be great to be able to use graphical error messages only in `development` mode and not in `production`.

What do you think about it?