### PR TITLE
fixes #57 by checking event details and setting overriding open

### DIFF
--- a/src/lib/Link.svelte
+++ b/src/lib/Link.svelte
@@ -52,6 +52,13 @@
 
   // this will enable `<Link on:click={...} />` calls
   function onClick(e) {
+    // user used a keyboard shortcut to force open link in a new tab
+    if (e.target.tagName === 'A' && (e.metaKey || e.ctrlKey || e.button !== 0)) {
+      return;
+    }
+    
+    e.preventDefault();
+
     if (typeof go === 'string' && window.history.length > 1) {
       if (go === 'back') window.history.back();
       else if (go === 'fwd') window.history.forward();
@@ -91,11 +98,11 @@
 </script>
 
 {#if button}
-  <button {...fixedProps} bind:this={ref} class={cssClass} {title} on:click|preventDefault={onClick}>
+  <button {...fixedProps} bind:this={ref} class={cssClass} {title} on:click={onClick}>
     <slot />
   </button>
 {:else}
-  <a {...fixedProps} href={cleanPath(fixedHref || href)} bind:this={ref} class={cssClass} {title} on:click|preventDefault={onClick}>
+  <a {...fixedProps} href={cleanPath(fixedHref || href)} bind:this={ref} class={cssClass} {title} on:click={onClick}>
     <slot />
   </a>
 {/if}


### PR DESCRIPTION
Since we're preventingDefault I went down the path of adding a variable to track if the user requested to force open in a new tab. Then based on that reuse the existing logic when we set `open` on Link.

fixes #57 