### PR TITLE
feat: adds in auto release and auto-publishing

### DIFF
--- a/.github/workflows/relase.yml
+++ b/.github/workflows/relase.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  Release:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - run: |
+          git config --local user.name "Release Bot"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - run: npm i
+      - run: npm run release
+      - name: Push Changes
+        uses: ad-m/github-push-action@master
+        with: 
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
+          tags: true
+      - name: Publish
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Closes #67 

You will need to add two secret variables to the repo, `GITHUB_TOKEN`, which needs write access, and `NPM_TOKEN` which you can generate from NPM.  This should only run when you make a push to the master branch. 

I tested an almost exact setup in my fork of the repository at https://github.com/jhechtf/yrv/tree/wip/auto-publish, which worked as expected. However, in that case I was publishing to a Verdaccio registry I setup on a self-hosted EC2 instance. I'll leave the EC2 instance up for the next couple of days JIC you want to see the registry to verify you can grab the URL from the linked branch.