### PR TITLE
fix: Adds changes to move to ubuntu runner instead of self-hosted

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,11 @@ name: Release
 on:
   push:
     branches:
-    - master
+      - master
 
 jobs:
   Release:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
         with:
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: "14"
       - run: |
           git config --local user.name "Release Bot"
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -23,7 +23,7 @@ jobs:
       - run: npm run release
       - name: Push Changes
         uses: ad-m/github-push-action@master
-        with: 
+        with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}
           tags: true


### PR DESCRIPTION
In my initial PR I didn't notice that I left the "self-hosted" in the `runs-on` value.

This should remedy that, and beside from not being able push files up due to conflicting tags seemed to function well on my fork.