### PR TITLE
chore(tooling): added  property main back to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.46",
   "description": "Your routing!",
   "types": "types/index.d.ts",
+  "main": "build/dist/index.js",
   "svelte": "build/dist/index.js",
   "files": [
     "build/**",


### PR DESCRIPTION
Fixes [78 Jest tests started to fail after main package.json property got removed](https://github.com/pateketrueke/yrv/issues/78)