### PR TITLE
chore: dev sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,21 +13,24 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-      - uses: actions/setup-node@v2
+
+      - uses: tacoss/nodejs@v2
         with:
-          node-version: "14"
+          args: make ci
+
       - run: |
           git config --local user.name "Release Bot"
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-      - run: npm i
-      - run: npm test
+
       - run: npm run release
+
       - name: Push Changes
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}
           tags: true
+
       - name: Publish
         run: make release && npm publish
         env:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,7 +9,10 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: tacoss/nodejs@master
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: tacoss/nodejs@v2
         with:
           args: make ci

--- a/e2e/components/Import.svelte
+++ b/e2e/components/Import.svelte
@@ -8,6 +8,6 @@
 
 <div data-test="container">
   <Router pending="Loading...">
-    <Route key="imported" fallback component={() => delay(import('./Example.svelte'))} />
+    <Route fallback component={() => delay(import('./Example.svelte'))} />
   </Router>
 </div>

--- a/e2e/components/Main.svelte
+++ b/e2e/components/Main.svelte
@@ -37,9 +37,9 @@
   <Link exact href="/example/a">Link</Link> | <Link exact href="/example/a/b">Broken link</Link>
 
   <p data-test="example">
-    <Route key="not-found" fallback>Not found?</Route>
-    <Route key="hello-world" exact>Hello World</Route>
-    <Route key="hello-name" exact path="/:name" let:router>Hello {router.params.name}</Route>
+    <Route fallback>Not found?</Route>
+    <Route exact>Hello World</Route>
+    <Route exact path="/:name" let:router>Hello {router.params.name}</Route>
   </p>
 </Router>
 
@@ -59,16 +59,16 @@
 </p>
 
 <p data-test="nested">
-  <Router key="top" path="/top">
-    <Route key="x" exact fallback>?</Route>
-    <Route key="a" exact path="/foo/a">a</Route>
-    <Route key="b" exact path="/bar/b">b</Route>
-    <Route key="c" exact path="/bar/c">c</Route>
+  <Router path="/top">
+    <Route exact fallback>?</Route>
+    <Route exact path="/foo/a">a</Route>
+    <Route exact path="/bar/b">b</Route>
+    <Route exact path="/bar/c">c</Route>
   </Router>
 </p>
 
 <Router path="/test" nofallback>
-  <Route key="test-root">
+  <Route>
     <h2>Testing features</h2>
 
     <p>This content is always mounted when the current URL starts-with <tt>/test</tt>.</p>
@@ -79,24 +79,24 @@
     | <Link href="/test/dynamic">Protected</Link>
 
     <p data-test="redirect">
-      <Route key="failed" path="/failed">Wrong!</Route>
-      <Route key="static" path="/static" redirect="/test" />
-      <Route key="dynamic" path="/dynamic" redirect="/test/failed" condition={() => /* eslint-disable no-alert */ window.confirm('Are you sure?')}>Yay!</Route>
+      <Route path="/failed">Wrong!</Route>
+      <Route path="/static" redirect="/test" />
+      <Route path="/dynamic" redirect="/test/failed" condition={() => /* eslint-disable no-alert */ window.confirm('Are you sure?')}>Yay!</Route>
     </p>
   </Route>
 
-  <Route key="props" path="/props" component={Testing} />
+  <Route path="/props" component={Testing} />
 
   <p data-test="routeless">Any <tt>Route</tt>-less content is always shown!</p>
 </Router>
 
 <div data-test="hashed">
-  <Router key="gist" path="/gist">
-    <Route key="main" exact>GIST INFO</Route>
+  <Router path="/gist">
+    <Route exact>GIST INFO</Route>
     <Router path="#:sha1" nofallback>
-      <Route key="show" let:router>SHA1: {router.params.sha1 || 'N/A'}</Route>
-      <Route key="edit" exact path="/edit">(edit)</Route>
-      <Route key="save" exact path="/save">(save)</Route>
+      <Route let:router>SHA1: {router.params.sha1 || 'N/A'}</Route>
+      <Route exact path="/edit">(edit)</Route>
+      <Route exact path="/save">(save)</Route>
     </Router>
   </Router>
 </div>
@@ -119,37 +119,37 @@
   | <Link href="/auth/protected">Protected page</Link>
 
   <Router path="/auth">
-    <Route key="secure" path="/protected" condition={() => loggedIn} redirect="/auth/login">O.K.</Route>
-    <Route key="login" path="/login">Log-in</Route>
+    <Route path="/protected" condition={() => loggedIn} redirect="/auth/login">O.K.</Route>
+    <Route path="/login">Log-in</Route>
 
-    <Route key="check" condition={() => loggedIn} exact redirect="/auth/login" />
-    <Route key="welcome" disabled={!loggedIn} exact>Welcome back.</Route>
+    <Route condition={() => loggedIn} exact redirect="/auth/login" />
+    <Route disabled={!loggedIn} exact>Welcome back.</Route>
   </Router>
 </div>
 
 <Router disabled={!loggedIn}>
   <p data-test="secret">
-    <Route key="sh">Shhhh! Top-secret</Route>
+    <Route>Shhhh! Top-secret</Route>
   </p>
 </Router>
 
 <Router path="/sub">
-  <Route key="sub">
+  <Route>
     <Link exact href="/sub#">Root</Link> | <Link href="/sub#/about">About page</Link> | <Link href="/sub#broken">Broken anchor</Link>
   </Route>
 
   <p data-test="anchored">
-    <Route key="home" exact path="#">HOME</Route>
-    <Route key="about" exact path="#/about">ABOUT</Route>
+    <Route exact path="#">HOME</Route>
+    <Route exact path="#/about">ABOUT</Route>
   </p>
 </Router>
 
 <Router path="/e">
-  <Route key="err" exact>
+  <Route exact>
     <h2>It works!</h2>
   </Route>
 
-  <Route key="404" fallback>
+  <Route fallback>
     <h2 data-test="fallback">NOT FOUND</h2>
   </Route>
 </Router>
@@ -161,9 +161,9 @@
 
 <p data-test="unordered">
   <Router path="/page">
-    <Route key="i" path="/:x/:y">I</Route>
-    <Route key="ii" path="/:x">II</Route>
-    <Route key="iii" path="/">III</Route>
+    <Route path="/:x/:y">I</Route>
+    <Route path="/:x">II</Route>
+    <Route path="/">III</Route>
   </Router>
 </p>
 

--- a/e2e/components/Testing.svelte
+++ b/e2e/components/Testing.svelte
@@ -64,7 +64,7 @@
 </fieldset>
 
 <Router>
-  <Route key="test-info" path="/:value" let:router>
+  <Route path="/:value" let:router>
     <p>Value: {router.params.value}</p>
   </Route>
 </Router>

--- a/e2e/components/nested-routers/App.svelte
+++ b/e2e/components/nested-routers/App.svelte
@@ -17,7 +17,7 @@
 <Router>
   {#if isLoggedIn}
     <Route key="home" exact component="{Home}" />
-    <Route key="players" path="/players" component="{Players}" />
+    <Route key="play" path="/players" component="{Players}" />
     <Route key="404" fallback component={NotFound} />
   {:else}
     <Route key="ask" fallback component={Login} />

--- a/e2e/components/nested-routers/Players.svelte
+++ b/e2e/components/nested-routers/Players.svelte
@@ -11,6 +11,6 @@
 <Link href="/players/team/new">New Team</Link>
 
 <Router>
-  <Route key="list" exact component="{List}" />
-  <Route key="new" path="/team/new" exact component="{NewTeam}" />
+  <Route exact component="{List}" />
+  <Route path="/team/new" exact component="{NewTeam}" />
 </Router>

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,5 @@
-import Router from './lib/Router.svelte';
-
-import { hashchangeEnable } from './lib/utils';
-
 export { default as Router } from './lib/Router.svelte';
 export { default as Route } from './lib/Route.svelte';
 export { default as Link } from './lib/Link.svelte';
 
 export { navigateTo, router } from './lib/utils';
-
-Object.defineProperty(Router, 'hashchange', {
-  set: value => hashchangeEnable(value),
-  get: () => hashchangeEnable(),
-  configurable: false,
-  enumerable: false,
-});

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,16 @@
+import Router from './lib/Router.svelte';
+
+import { hashchangeEnable } from './lib/utils';
+
 export { default as Router } from './lib/Router.svelte';
 export { default as Route } from './lib/Route.svelte';
 export { default as Link } from './lib/Link.svelte';
 
 export { navigateTo, router } from './lib/utils';
+
+Object.defineProperty(Router, 'hashchange', {
+  set: value => hashchangeEnable(value),
+  get: () => hashchangeEnable(),
+  configurable: false,
+  enumerable: false,
+});

--- a/src/lib/Route.svelte
+++ b/src/lib/Route.svelte
@@ -68,10 +68,6 @@
       throw new TypeError(`Missing top-level <Router>, given route: ${path}`);
     }
 
-    if (!key) {
-      throw new TypeError(`Expecting a key per-route definition, given route: ${path}`);
-    }
-
     resolve();
   } catch (e) {
     failure = e;

--- a/src/lib/Router.svelte
+++ b/src/lib/Router.svelte
@@ -49,6 +49,8 @@
   // ENDIF
 
   function assignRoute(_key, route, detail) {
+    _key = _key || `route-${Math.random().toString(36).substr(2)}`;
+
     const $key = [key, _key].filter(Boolean).join('.');
     const handler = { key: $key, ...detail };
 

--- a/src/lib/router.js
+++ b/src/lib/router.js
@@ -82,16 +82,16 @@ export function evtHandler() {
 
   // trailing slash is required to keep route-info on nested routes!
   // see: https://github.com/pateketrueke/abstract-nested-router/commit/0f338384bddcfbaee30f3ea2c4eb0c24cf5174cd
-  const [fixedUri, qs] = baseUri.replace('/#', '#').replace(/^#\//, '/').split('?');
-  const fullpath = fixedUri.replace(/\/?$/, '/');
-  const query = parse(qs);
+  const normalizedURL = baseUri.replace('/#', '#').replace(/^#\//, '/');
+  const [path, qs] = normalizedURL.split('?');
+  const fullpath = path.replace(/\/?$/, '/');
   const params = {};
 
-  if (currentURL !== baseUri) {
-    currentURL = baseUri;
+  if (currentURL !== normalizedURL) {
+    currentURL = normalizedURL;
     router.set({
       path: cleanPath(fullpath),
-      query,
+      query: parse(qs),
       params,
     });
   }


### PR DESCRIPTION
A regression was made on `v0.0.55` which blocked users to have routes without keys, also the `currentURL` check used to update the `router` store was not working as previously... now it does!

Now, keys are completely optional as previous releases, but on specific cases is worth to use them (i.e. to avoid remounting issues)

See: https://github.com/pateketrueke/yrv/blob/master/e2e/components/nested-routers/App.svelte#L18-L24